### PR TITLE
Improve Codex CLI implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+current_context.txt

--- a/codex_cli/__init__.py
+++ b/codex_cli/__init__.py
@@ -1,0 +1,3 @@
+from .cli import CodexCLI
+
+__all__ = ["CodexCLI"]

--- a/codex_cli/cli.py
+++ b/codex_cli/cli.py
@@ -1,0 +1,49 @@
+import openai
+
+from .prompt import Prompt
+from .commands import handle_command
+
+
+class CodexCLI:
+    def __init__(self, model: str = 'codex-mini-latest', temperature: float = 0.0, max_tokens: int = 512):
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.prompt = Prompt()
+
+    def query(self, text: str) -> str:
+        messages = self.prompt.get_messages()
+        messages.append({"role": "user", "content": text})
+        resp = openai.ChatCompletion.create(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+        return resp["choices"][0]["message"]["content"]
+
+    def interact(self, line: str):
+        cmd_result = handle_command(line, self)
+        if cmd_result is not None:
+            return cmd_result
+        response = self.query(line)
+        if self.prompt.multi_turn:
+            self.prompt.add_interaction(line, response)
+        return response
+
+
+def main():
+    cli = CodexCLI()
+    print("Codex CLI (python) - type '# help' for commands")
+    try:
+        while True:
+            line = input('> ')
+            out = cli.interact(line)
+            print(out)
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+
+if __name__ == '__main__':
+    main()

--- a/codex_cli/commands.py
+++ b/codex_cli/commands.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+
+def handle_command(line: str, cli) -> Optional[str]:
+    """Handle special commands starting with '#'.
+
+    Returns message if handled, None otherwise.
+    """
+    if not line.strip().startswith('#'):
+        return None
+    cmd = line.strip()[1:].strip()
+
+    if cmd.startswith('start multi-turn'):
+        cli.prompt.multi_turn = True
+        return 'multi-turn on'
+    if cmd.startswith('stop multi-turn'):
+        cli.prompt.multi_turn = False
+        cli.prompt.clear()
+        return 'multi-turn off'
+    if cmd.startswith('clear context'):
+        cli.prompt.clear()
+        return 'context cleared'
+    if cmd.startswith('load context'):
+        parts = cmd.split(maxsplit=2)
+        if len(parts) == 3:
+            cli.prompt.load(parts[2])
+            return 'context loaded'
+        return 'missing filename'
+    if cmd.startswith('save context'):
+        parts = cmd.split(maxsplit=2)
+        name = parts[2] if len(parts) == 3 else 'context.txt'
+        cli.prompt.save(name)
+        return f'saved to {name}'
+    if cmd.startswith('set model'):
+        parts = cmd.split()
+        if len(parts) == 3:
+            cli.model = parts[2]
+            return f'model set to {cli.model}'
+    if cmd.startswith('set temperature'):
+        parts = cmd.split()
+        if len(parts) == 3:
+            cli.temperature = float(parts[2])
+            return f'temperature set to {cli.temperature}'
+    if cmd.startswith('show config'):
+        return f'model={cli.model} temp={cli.temperature} multi_turn={cli.prompt.multi_turn}'
+
+    return 'unknown command'

--- a/codex_cli/prompt.py
+++ b/codex_cli/prompt.py
@@ -1,0 +1,48 @@
+import os
+from pathlib import Path
+
+class Prompt:
+    """Simple prompt context management."""
+    def __init__(self, path: str = "current_context.txt"):
+        self.path = Path(path)
+        self.multi_turn = False
+        self.path.write_text("")  # ensure file exists
+
+    def clear(self):
+        self.path.write_text("")
+
+    def add_interaction(self, user: str, response: str):
+        if not self.multi_turn:
+            return
+        with self.path.open("a") as f:
+            f.write(user.rstrip() + "\n")
+            f.write(response.rstrip() + "\n")
+
+    def get_context(self) -> str:
+        if not self.multi_turn:
+            return ""
+        return self.path.read_text()
+
+    def get_messages(self):
+        if not self.multi_turn:
+            return []
+        lines = self.path.read_text().splitlines()
+        messages = []
+        for i in range(0, len(lines), 2):
+            user = lines[i]
+            messages.append({"role": "user", "content": user})
+            if i + 1 < len(lines):
+                assistant = lines[i + 1]
+                messages.append({"role": "assistant", "content": assistant})
+        return messages
+
+    def load(self, filename: str):
+        src = Path(filename)
+        if src.exists():
+            self.path.write_text(src.read_text())
+        else:
+            raise FileNotFoundError(filename)
+
+    def save(self, filename: str):
+        dst = Path(filename)
+        dst.write_text(self.path.read_text())

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from codex_cli.cli import main
+
+if __name__ == '__main__':
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,20 @@
+from codex_cli.cli import CodexCLI
+from codex_cli.commands import handle_command
+
+
+def test_start_stop_multi_turn():
+    cli = CodexCLI()
+    msg = handle_command('# start multi-turn', cli)
+    assert msg == 'multi-turn on'
+    assert cli.prompt.multi_turn is True
+    msg = handle_command('# stop multi-turn', cli)
+    assert msg == 'multi-turn off'
+    assert cli.prompt.multi_turn is False
+
+
+def test_set_model_and_temp():
+    cli = CodexCLI()
+    handle_command('# set model test-model', cli)
+    assert cli.model == 'test-model'
+    handle_command('# set temperature 0.5', cli)
+    assert cli.temperature == 0.5

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,29 @@
+import tempfile
+from pathlib import Path
+from codex_cli.prompt import Prompt
+
+
+def test_add_interaction_and_context():
+    with tempfile.TemporaryDirectory() as tmp:
+        pfile = Path(tmp)/"context.txt"
+        prompt = Prompt(str(pfile))
+        prompt.multi_turn = True
+        prompt.add_interaction("hello", "world")
+        ctx = prompt.get_context()
+        assert "hello" in ctx and "world" in ctx
+        msgs = prompt.get_messages()
+        assert msgs == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+
+
+def test_load_and_save():
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp)/"src.txt"
+        dst = Path(tmp)/"dst.txt"
+        src.write_text("line1\nline2\n")
+        prompt = Prompt(str(Path(tmp)/"context.txt"))
+        prompt.load(str(src))
+        prompt.save(str(dst))
+        assert dst.read_text() == "line1\nline2\n"


### PR DESCRIPTION
## Summary
- switch to ChatCompletion API and default model `codex-mini-latest`
- add `# set model` command and show model in `show config`
- expose conversation history as Chat messages
- add test fixture for package import path
- update unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687125206dc88333ae91a01d763d0799